### PR TITLE
feature/RecoilSetting/28

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-lottie": "^1.2.3",
     "react-router-dom": "^6.9.0",
     "react-scripts": "5.0.1",
+    "recoil": "^0.7.7",
     "style-loader": "^3.3.2",
     "tui-color-picker": "^2.2.8",
     "typescript": "^4.4.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,12 @@
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 import App from './App';
 import 'styles/reset.scss';
 import 'styles/global.scss';
+import { RecoilRoot } from 'recoil';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement,
+ReactDOM.render(
+  <RecoilRoot>
+    <App />
+  </RecoilRoot>,
+  document.getElementById('root'),
 );
-root.render(<App />);

--- a/src/pages/NodeMap/components/Modal/index.tsx
+++ b/src/pages/NodeMap/components/Modal/index.tsx
@@ -4,13 +4,10 @@ import Modal from 'react-modal';
 import WriteModal from 'pages/NodeMap/components/WriteModal';
 import { ModalProps } from 'utils/types';
 import ListModal from '../ListModal';
+import { useRecoilValue } from 'recoil';
+import { nodeAtom } from 'recoil/state';
 
-function NodeModal({
-  isOpen,
-  onRequestClose,
-  selectedNodeInfo,
-  updateNodeInfo,
-}: ModalProps) {
+function NodeModal({ isOpen, onRequestClose, updateNodeInfo }: ModalProps) {
   const [writeModalIsOpen, setWriteModalIsOpen] = useState(false);
 
   const openWriteModal = () => {
@@ -23,6 +20,8 @@ function NodeModal({
     setListModalIsOpen(true);
     onRequestClose();
   };
+
+  const selectedNodeInfo = useRecoilValue(nodeAtom);
 
   return (
     <>
@@ -66,7 +65,6 @@ function NodeModal({
         </div>
       </Modal>
       <WriteModal
-        nodeInfo={selectedNodeInfo}
         isOpen={writeModalIsOpen}
         updateNodeInfo={updateNodeInfo}
         onRequestClose={() => setWriteModalIsOpen(false)}

--- a/src/pages/NodeMap/components/WriteModal/index.tsx
+++ b/src/pages/NodeMap/components/WriteModal/index.tsx
@@ -8,13 +8,15 @@ import '@toast-ui/editor/dist/toastui-editor-viewer.css';
 import styles from './WriteModal.module.scss';
 import { WriteModalProps } from 'utils/types';
 import ResizableModal from 'components/ResizebleModal';
+import { nodeAtom } from 'recoil/state';
+import { useRecoilValue } from 'recoil';
 
 const WriteModal = ({
   isOpen,
   onRequestClose,
-  nodeInfo,
   updateNodeInfo,
 }: WriteModalProps) => {
+  const nodeInfo = useRecoilValue(nodeAtom);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [isActive, setIsActive] = useState(nodeInfo.isActive);

--- a/src/pages/NodeMap/index.tsx
+++ b/src/pages/NodeMap/index.tsx
@@ -6,10 +6,11 @@ import Loading from 'components/Loading';
 import Modal from 'react-modal';
 import NodeModal from 'pages/NodeMap/components/Modal';
 import { getNodeList } from 'api/Node';
+import { useRecoilState } from 'recoil';
+import { nodeAtom } from 'recoil/state';
 
 const NodeMap = () => {
   // eslint-disable-next-line
-
   const [initialLoad, setInitialLoad] = useState(true);
   const fgRef = useRef<any>();
   const [nodeData, setNodeData] = useState(null);
@@ -18,13 +19,19 @@ const NodeMap = () => {
 
   // modal
   const [modalIsOpen, setModalIsOpen] = useState(false);
-  const [selectedNode, setSelectedNode] = useState(null);
   Modal.setAppElement('#root');
+
+  // recoil
+  const [nodeInfo, setNodeInfo] = useRecoilState(nodeAtom);
+  const nodeSelected: NodeObject = { id: 0, isActive: false, name: '' };
 
   const handleClick = (node: NodeObject) => {
     fgRef.current?.centerAt(node.x, node.y, 1000);
-    setSelectedNode(node);
     setModalIsOpen(true);
+    nodeSelected.id = node.id;
+    nodeSelected.isActive = node.isActive;
+    nodeSelected.name = node.name;
+    setNodeInfo(nodeSelected);
   };
 
   const drawStart = (ctx: Context, node: Node, nodeSize: number) => {
@@ -184,12 +191,11 @@ const NodeMap = () => {
         <Loading />
       )}
 
-      {selectedNode && (
+      {nodeInfo && (
         <>
           <NodeModal
             isOpen={modalIsOpen}
             onRequestClose={() => setModalIsOpen(false)}
-            selectedNodeInfo={selectedNode}
             updateNodeInfo={handleNodeInfoUpdate}
           />
         </>

--- a/src/pages/NodeMap/index.tsx
+++ b/src/pages/NodeMap/index.tsx
@@ -23,15 +23,11 @@ const NodeMap = () => {
 
   // recoil
   const [nodeInfo, setNodeInfo] = useRecoilState(nodeAtom);
-  const nodeSelected: NodeObject = { id: 0, isActive: false, name: '' };
 
   const handleClick = (node: NodeObject) => {
     fgRef.current?.centerAt(node.x, node.y, 1000);
     setModalIsOpen(true);
-    nodeSelected.id = node.id;
-    nodeSelected.isActive = node.isActive;
-    nodeSelected.name = node.name;
-    setNodeInfo(nodeSelected);
+    setNodeInfo({ id: node.id, isActive: node.isActive, name: node.name });
   };
 
   const drawStart = (ctx: Context, node: Node, nodeSize: number) => {

--- a/src/recoil/state.tsx
+++ b/src/recoil/state.tsx
@@ -1,10 +1,9 @@
 import { atom } from 'recoil';
 import { NodeObject } from 'utils/types';
 
-// eslint-disable-next-line prefer-const
-let nodeInfo: NodeObject = { id: 0, isActive: false, name: '' };
+const initalNodeInfo: NodeObject = { id: 0, isActive: false, name: '' };
 
 export const nodeAtom = atom({
   key: 'nodeAtom',
-  default: nodeInfo,
+  default: initalNodeInfo,
 });

--- a/src/recoil/state.tsx
+++ b/src/recoil/state.tsx
@@ -1,0 +1,10 @@
+import { atom } from 'recoil';
+import { NodeObject } from 'utils/types';
+
+// eslint-disable-next-line prefer-const
+let nodeInfo: NodeObject = { id: 0, isActive: false, name: '' };
+
+export const nodeAtom = atom({
+  key: 'nodeAtom',
+  default: nodeInfo,
+});

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,6 +4,7 @@ export type NodeObject = object & {
   name?: string;
   x?: number;
   y?: number;
+  isActive?: boolean;
   vx?: number;
   vy?: number;
   fx?: number;
@@ -32,7 +33,6 @@ export interface FormBoxProps {
 export interface ModalProps {
   isOpen: boolean;
   onRequestClose: () => void;
-  selectedNodeInfo: Node;
   updateNodeInfo: (id: number | string, isActive: boolean) => void;
 }
 
@@ -40,7 +40,6 @@ export interface ModalProps {
 export interface WriteModalProps {
   isOpen: boolean;
   onRequestClose: () => void;
-  nodeInfo: Node;
   updateNodeInfo: (id: number | string, isActive: boolean) => void;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5373,6 +5373,11 @@ gzip-size@^6.0.0:
   dependencies:
     duplexer "^0.1.2"
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -8633,6 +8638,13 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+recoil@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"
+  integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==
+  dependencies:
+    hamt_plus "1.0.2"
 
 recursive-readdir@^2.2.2:
   version "2.2.3"


### PR DESCRIPTION
## Summary
Recoil 초반 세팅

## Description
- atom 설정
- 선택된 노드 정보로 atom값 변경 후 변경된 값을 불러와서 기존의 props로 넘기던 코드를 수정

## Screenshots
![image](https://github.com/techeer-sv/Mindspace_front/assets/105929978/4d5cc7b7-09f8-43e1-b71a-caca38449527)


## Test Checklist
- [x] 기존의 기능이 제대로 동작하는 지(선택된 노드의 이름이 보이고, 글 삭제 및 수정이 되는지)