### PR TITLE
Feature/modal size/31

### DIFF
--- a/src/components/ResizebleModal/index.tsx
+++ b/src/components/ResizebleModal/index.tsx
@@ -10,11 +10,11 @@ const ResizableModal = ({
   onRequestClose,
   children,
 }: ResizableModalProps) => {
-  const minWidth = 800;
-  const minHeight = 600;
+  const minWidth = window.innerWidth * 0.5;
+  const minHeight = window.innerHeight * 0.6;
 
   const maxWidth = window.innerWidth - 50;
-  const maxHeight = window.innerWidth - 440;
+  const maxHeight = window.innerHeight - 76 * 2;
 
   const [isResizing, setIsResizing] = useState(false);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });

--- a/src/components/ResizebleModal/index.tsx
+++ b/src/components/ResizebleModal/index.tsx
@@ -3,11 +3,7 @@ import Modal from 'react-modal';
 import styles from './ResizebleModal.module.scss';
 import { ResizableModalProps } from 'utils/types';
 import { useRecoilState } from 'recoil';
-import {
-  ModalWidthAtom,
-  ModalHeightAtom,
-  mousePositionAtom,
-} from 'recoil/state/resizeAtom';
+import { ModalWidthAtom, ModalHeightAtom } from 'recoil/state/resizeAtom';
 
 const ResizableModal = ({
   isOpen,
@@ -16,17 +12,15 @@ const ResizableModal = ({
 }: ResizableModalProps) => {
   const minWidth = 800;
   const minHeight = 600;
-  const maxWidth = window.innerWidth - 30;
-  const maxHeight = window.innerHeight - 30;
+
+  const maxWidth = window.innerWidth - 50;
+  const maxHeight = window.innerWidth - 440;
 
   const [isResizing, setIsResizing] = useState(false);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
-  // const [mousePosition, setMousePosition] = useRecoilState(ModalWidthAtom);
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     setIsResizing(true);
-    console.log(typeof e.clientX);
-
     setMousePosition({ x: e.clientX, y: e.clientY });
   };
 

--- a/src/components/ResizebleModal/index.tsx
+++ b/src/components/ResizebleModal/index.tsx
@@ -2,6 +2,12 @@ import React, { useEffect, useState } from 'react';
 import Modal from 'react-modal';
 import styles from './ResizebleModal.module.scss';
 import { ResizableModalProps } from 'utils/types';
+import { useRecoilState } from 'recoil';
+import {
+  ModalWidthAtom,
+  ModalHeightAtom,
+  mousePositionAtom,
+} from 'recoil/state/resizeAtom';
 
 const ResizableModal = ({
   isOpen,
@@ -13,15 +19,19 @@ const ResizableModal = ({
   const maxWidth = window.innerWidth - 30;
   const maxHeight = window.innerHeight - 30;
 
-  const [modalWidth, setModalWidth] = useState(minWidth);
-  const [modalHeight, setModalHeight] = useState(minHeight);
   const [isResizing, setIsResizing] = useState(false);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+  // const [mousePosition, setMousePosition] = useRecoilState(ModalWidthAtom);
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     setIsResizing(true);
+    console.log(typeof e.clientX);
+
     setMousePosition({ x: e.clientX, y: e.clientY });
   };
+
+  const [modalWidth, setModalWidth] = useRecoilState(ModalWidthAtom);
+  const [modalHeight, setModalHeight] = useRecoilState(ModalHeightAtom);
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
@@ -49,7 +59,16 @@ const ResizableModal = ({
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
     };
-  }, [isResizing, mousePosition, minWidth, minHeight, maxWidth, maxHeight]);
+  }, [
+    isResizing,
+    mousePosition,
+    minWidth,
+    minHeight,
+    maxWidth,
+    maxHeight,
+    setModalWidth,
+    setModalHeight,
+  ]);
 
   return (
     <Modal

--- a/src/pages/NodeMap/components/PostTable/index.tsx
+++ b/src/pages/NodeMap/components/PostTable/index.tsx
@@ -4,6 +4,8 @@ import { AgGridReact } from 'ag-grid-react';
 import { CellClickedEvent } from 'ag-grid-community';
 import { useEffect, useState } from 'react';
 import { getPostListData } from 'api/Post';
+import { useRecoilValue } from 'recoil';
+import { ModalWidthAtom, ModalHeightAtom } from 'recoil/state/resizeAtom';
 
 interface PostTableProps {
   OnClickedId: (id: number) => void;
@@ -29,10 +31,17 @@ function PostTable({ OnClickedId }: PostTableProps) {
     OnClickedId(params.data.id);
   };
 
+  const modalWidth = useRecoilValue(ModalWidthAtom);
+  const modalHeight = useRecoilValue(ModalHeightAtom);
+
   return (
     <div
       className="ag-theme-alpine"
-      style={{ width: 750, height: 550, margin: 'auto auto' }}
+      style={{
+        width: modalWidth,
+        height: modalHeight - 70,
+        margin: 'auto auto',
+      }}
     >
       <AgGridReact
         rowData={rowData}

--- a/src/recoil/state/resizeAtom.tsx
+++ b/src/recoil/state/resizeAtom.tsx
@@ -1,7 +1,5 @@
 import { atom } from 'recoil';
 
-const initalMousePostion = { x: 0, y: 0 };
-
 export const ModalWidthAtom = atom({
   key: 'ModalWidth',
   default: 800,
@@ -10,9 +8,4 @@ export const ModalWidthAtom = atom({
 export const ModalHeightAtom = atom({
   key: 'ModalHeight',
   default: 800,
-});
-
-export const mousePositionAtom = atom({
-  key: 'mousePosition',
-  default: initalMousePostion,
 });

--- a/src/recoil/state/resizeAtom.tsx
+++ b/src/recoil/state/resizeAtom.tsx
@@ -2,10 +2,10 @@ import { atom } from 'recoil';
 
 export const ModalWidthAtom = atom({
   key: 'ModalWidth',
-  default: 800,
+  default: window.innerWidth * 0.8,
 });
 
 export const ModalHeightAtom = atom({
   key: 'ModalHeight',
-  default: 800,
+  default: window.innerHeight * 0.6,
 });

--- a/src/recoil/state/resizeAtom.tsx
+++ b/src/recoil/state/resizeAtom.tsx
@@ -1,0 +1,18 @@
+import { atom } from 'recoil';
+
+const initalMousePostion = { x: 0, y: 0 };
+
+export const ModalWidthAtom = atom({
+  key: 'ModalWidth',
+  default: 800,
+});
+
+export const ModalHeightAtom = atom({
+  key: 'ModalHeight',
+  default: 800,
+});
+
+export const mousePositionAtom = atom({
+  key: 'mousePosition',
+  default: initalMousePostion,
+});


### PR DESCRIPTION
## Summary
Recoil에 모달 창 크기 정보 저장

## Description
- Recoil에 모달 창 크기의 정보(width, height)저장
- 저장된 값으로 글 작성 시와 글 목록 조회 시 이전과 같은 크기의 모달창으로 보이도록 구현
- 커진 모달창이 상단바를 가리지 않도록 구현
- 글 목록 컴포넌트가 늘어난 모달창에 맞춰서 같이 늘어나도록 구현

## Screenshots
![image](https://github.com/techeer-sv/Mindspace_front/assets/105929978/5b97c123-43a0-47d9-92db-b5ccbd15998b)
![image](https://github.com/techeer-sv/Mindspace_front/assets/105929978/3cefe341-3937-4a1b-a109-497fd16ea9d9)
![image](https://github.com/techeer-sv/Mindspace_front/assets/105929978/381eda8c-45d1-4f78-bea3-cb55326bbba5)


## Test Checklist
- [x] 글 목록 조회와 글 작성 시 같은 모달창의 크기로 보이는 지
- [x] 모달창을 늘렸을 때, 상단바를 가리지 않는 지
- [x] 글 목록 컴포넌트가 늘어난 모달창을 따라 같이 늘어나는 지