### PR TITLE
Feature/node api/46

### DIFF
--- a/src/api/Node.ts
+++ b/src/api/Node.ts
@@ -1,5 +1,5 @@
 import axios from '@/utils/baseAxios';
-import { NodeObject, Node } from '@/utils/types';
+import { GraphData, Node } from '@/utils/types';
 
 /**
  * // TODO
@@ -9,7 +9,7 @@ import { NodeObject, Node } from '@/utils/types';
  * 더미 데이터 기반의 정보를 프론트에서 가공해서 사용합니다.
  */
 
-export const getNodeList = async (): Promise<NodeObject> => {
+export const getNodeList = async (): Promise<GraphData> => {
   const response = await axios.get('node/check');
 
   const nodeData = response.data;

--- a/src/api/Node.ts
+++ b/src/api/Node.ts
@@ -9,11 +9,6 @@ import { NodeObject, Node } from '@/utils/types';
  * 더미 데이터 기반의 정보를 프론트에서 가공해서 사용합니다.
  */
 
-interface GetAccessTokenParams {
-  email: string;
-  password: string;
-}
-
 export const getNodeList = async (): Promise<NodeObject> => {
   const response = await axios.get('node/check');
 
@@ -155,5 +150,6 @@ export const getNodeList = async (): Promise<NodeObject> => {
     links: dummyLink,
   };
 
+  console.log('here', nodeList);
   return nodeList;
 };

--- a/src/api/Node.ts
+++ b/src/api/Node.ts
@@ -150,6 +150,5 @@ export const getNodeList = async (): Promise<GraphData> => {
     links: dummyLink,
   };
 
-  console.log('here', nodeList);
   return nodeList;
 };

--- a/src/api/Node.ts
+++ b/src/api/Node.ts
@@ -1,17 +1,23 @@
-import axios from 'axios';
+import axios from '@/utils/baseAxios';
 import { NodeObject, Node } from '@/utils/types';
 
 /**
+ * // TODO
  * 작성자 : 태원
  * 날짜 : 4/20
- * 내용 : Link의 경우 백엔드 개발 전 까지 임시로 더미데이터를 사용합니다. 이에 따라 Node객체의 connect_count값도
+ * 내용 : Link의 경우 백엔드 개발 전 까지 임시로 더미데이터를 사용합니다. 이에 따라 Node객체의 connectCount값도
  * 더미 데이터 기반의 정보를 프론트에서 가공해서 사용합니다.
  */
 
+interface GetAccessTokenParams {
+  email: string;
+  password: string;
+}
+
 export const getNodeList = async (): Promise<NodeObject> => {
-  await new Promise((resolve) => setTimeout(resolve, 1000)); // Loading 테스트
-  const res = await axios.get('../dummy/nodeList.json');
-  const nodeData = res.data;
+  const response = await axios.get('node/check');
+
+  const nodeData = response.data;
 
   const dummyLink = [
     {
@@ -133,7 +139,7 @@ export const getNodeList = async (): Promise<NodeObject> => {
   ];
 
   const nodeList = {
-    nodes: nodeData.nodes.map((node: Node) => {
+    nodes: nodeData.map((node: Node) => {
       const connectCount = dummyLink.reduce((acc, link) => {
         if (link.source === node.id || link.target === node.id) {
           acc += 1;
@@ -143,7 +149,7 @@ export const getNodeList = async (): Promise<NodeObject> => {
 
       return {
         ...node,
-        connect_count: connectCount,
+        connectCount: connectCount,
       };
     }),
     links: dummyLink,

--- a/src/hooks/queries/node.ts
+++ b/src/hooks/queries/node.ts
@@ -1,0 +1,9 @@
+import { useQuery } from 'react-query';
+import { getNodeList } from '@/api/Node';
+import { KEY } from '@/utils/constants';
+
+export const useNodeListQuery = () => {
+  return useQuery([KEY.NODE_LIST], getNodeList, {
+    staleTime: Infinity,
+  });
+};

--- a/src/pages/NodeMap/components/Modal/index.tsx
+++ b/src/pages/NodeMap/components/Modal/index.tsx
@@ -53,7 +53,7 @@ function NodeModal({ isOpen, onRequestClose, updateNodeInfo }: ModalProps) {
           <span className={styles.content__title}>{selectedNodeInfo.name}</span>
           <div>
             <button onClick={openWriteModal} className={styles.content__button}>
-              {selectedNodeInfo.isActive ? '조회' : '작성'}
+              {selectedNodeInfo.isWritten ? '조회' : '작성'}
             </button>
             <button
               onClick={handleClickLIst}

--- a/src/pages/NodeMap/components/WriteModal/index.tsx
+++ b/src/pages/NodeMap/components/WriteModal/index.tsx
@@ -18,7 +18,7 @@ const WriteModal = ({
   const nodeInfo = useRecoilValue(nodeAtom);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [isActive, setIsActive] = useState(nodeInfo.isActive);
+  const [isWritten, setIsWritten] = useState(nodeInfo.isWritten);
   const [initTitle, setInitTitle] = useState(title);
   const [initEditedContent, setInitEditedContent] = useState(content);
   const [isEditing, setIsEditing] = useState(true);
@@ -38,7 +38,7 @@ const WriteModal = ({
   const handleFirstWrite = async () => {
     await createPost(nodeInfo.id as number, title, content);
     setIsEditing(false);
-    setIsActive(true);
+    setIsWritten(true);
     updateNodeInfo(nodeInfo?.id, true);
     setIsLoading(false);
   };
@@ -53,7 +53,7 @@ const WriteModal = ({
   const handleDelete = async () => {
     await deletePost(nodeInfo.id as number);
     updateNodeInfo(nodeInfo?.id, false);
-    setIsActive(false);
+    setIsWritten(false);
     onRequestClose();
   };
 
@@ -65,9 +65,9 @@ const WriteModal = ({
 
   useEffect(() => {
     setIsLoading(true);
-    setIsActive(nodeInfo.isActive);
+    setIsWritten(nodeInfo.isWritten);
 
-    if (isOpen && nodeInfo?.isActive) {
+    if (isOpen && nodeInfo?.isWritten) {
       const fetchData = async () => {
         const data = await getPost(nodeInfo.id as number);
 
@@ -88,7 +88,7 @@ const WriteModal = ({
 
   return (
     <ResizableModal isOpen={isOpen} onRequestClose={onRequestClose}>
-      {isActive ? (
+      {isWritten ? (
         <>
           <div className={styles.header}>
             <button className={styles.header__button} onClick={onRequestClose}>

--- a/src/pages/NodeMap/index.tsx
+++ b/src/pages/NodeMap/index.tsx
@@ -98,12 +98,12 @@ const NodeMap = () => {
   };
 
   const nodeCanvasObject = (node: Node, ctx: Context) => {
-    node.connect_count = node.connect_count || 0;
+    node.connectCount = node.connectCount || 0;
     node.x = node.x || 0;
     node.y = node.y || 0;
     node.name = node.name || '';
 
-    const nodeSize = nodeVal * nodeRelSize * (node.connect_count * 0.2 + 1);
+    const nodeSize = nodeVal * nodeRelSize * (node.connectCount * 0.2 + 1);
 
     if (node.isWritten) {
       ctx.fillStyle = 'yellow';
@@ -112,13 +112,13 @@ const NodeMap = () => {
     }
 
     switch (true) {
-      case node.connect_count <= 2:
+      case node.connectCount <= 2:
         drawStart(ctx, node, nodeSize);
         break;
-      case node.connect_count >= 3 && node.connect_count < 5:
+      case node.connectCount >= 3 && node.connectCount < 5:
         drawStart(ctx, node, nodeSize);
         break;
-      case node.connect_count >= 5:
+      case node.connectCount >= 5:
         drawCircle(ctx, node, nodeSize);
         break;
       default:

--- a/src/pages/NodeMap/index.tsx
+++ b/src/pages/NodeMap/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { ForceGraph2D } from 'react-force-graph';
-import { NodeObject, Node, Context } from '@/utils/types';
+import { NodeObject, Node, Context, GraphData } from '@/utils/types';
 import Navbar from '@/components/Navbar';
 import Loading from '@/components/Loading';
 import Modal from 'react-modal';
@@ -10,13 +10,13 @@ import { nodeAtom } from '@/recoil/state/nodeAtom';
 import { useNodeListQuery } from '@/hooks/queries/node';
 const NodeMap = () => {
   // eslint-disable-next-line
-  const [nodeData, setNodeData] = useState(null);
+  const [nodeData, setNodeData] = useState<GraphData>(null);
   const fgRef = useRef<any>();
   const nodeRelSize = 3;
   const nodeVal = 3;
 
   // modal
-  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);
   Modal.setAppElement('#root');
 
   // recoil
@@ -144,6 +144,7 @@ const NodeMap = () => {
   useEffect(() => {
     if (status === 'success') {
       setNodeData(data);
+
       setTimeout(() => {
         fgRef.current?.d3Force('charge').strength(-500).distanceMax(300);
         fgRef.current?.d3Force('link').distance(70);
@@ -152,7 +153,7 @@ const NodeMap = () => {
       setTimeout(() => {
         if (fgRef.current) {
           fgRef.current.zoomToFit(1000);
-          nodeData.nodes.forEach((node: Node) => {
+          data.nodes.forEach((node: Node) => {
             node.fx = node.x;
             node.fy = node.y;
           });

--- a/src/pages/NodeMap/index.tsx
+++ b/src/pages/NodeMap/index.tsx
@@ -27,7 +27,7 @@ const NodeMap = () => {
   const handleClick = (node: NodeObject) => {
     fgRef.current?.centerAt(node.x, node.y, 1000);
     setModalIsOpen(true);
-    setNodeInfo({ id: node.id, isActive: node.isActive, name: node.name });
+    setNodeInfo({ id: node.id, isWritten: node.isWritten, name: node.name });
   };
 
   const drawStart = (ctx: Context, node: Node, nodeSize: number) => {
@@ -105,7 +105,7 @@ const NodeMap = () => {
 
     const nodeSize = nodeVal * nodeRelSize * (node.connect_count * 0.2 + 1);
 
-    if (node.isActive) {
+    if (node.isWritten) {
       ctx.fillStyle = 'yellow';
     } else {
       ctx.fillStyle = 'white';
@@ -131,10 +131,10 @@ const NodeMap = () => {
     ctx.fillText(node.name, node.x, node.y + nodeSize + 12);
   };
 
-  const handleNodeInfoUpdate = (id: number | string, isActive: boolean) => {
+  const handleNodeInfoUpdate = (id: number | string, isWritten: boolean) => {
     const updatedNodeData = {
       nodes: nodeData.nodes.map((node: Node) =>
-        node.id === id ? { ...node, isActive: isActive } : node,
+        node.id === id ? { ...node, isWritten: isWritten } : node,
       ),
       links: nodeData.links,
     };

--- a/src/recoil/state/nodeAtom.tsx
+++ b/src/recoil/state/nodeAtom.tsx
@@ -1,7 +1,7 @@
 import { atom } from 'recoil';
 import { NodeObject } from '@/utils/types';
 
-const initalNodeInfo: NodeObject = { id: 0, isActive: false, name: '' };
+const initalNodeInfo: NodeObject = { id: 0, isWritten: false, name: '' };
 
 export const nodeAtom = atom({
   key: 'nodeAtom',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,4 +3,5 @@ export const NAVBAR_HEIGHT = 76;
 // queryKey 상수
 export const KEY: Record<string, string> = {
   USER_NICKNAME: 'userNickname',
+  NODE_LIST: 'nodeList',
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -18,11 +18,11 @@ export interface Node extends NodeObject {
 }
 
 interface Link {
-  source: Node;
-  target: Node;
-  __indexColor: string;
-  __controlPoints: null;
-  index: number;
+  source: Node | number;
+  target: Node | number;
+  __indexColor?: string;
+  __controlPoints?: null;
+  index?: number;
 }
 
 export interface GraphData {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -17,6 +17,19 @@ export interface Node extends NodeObject {
   isWritten?: boolean;
 }
 
+interface Link {
+  source: Node;
+  target: Node;
+  __indexColor: string;
+  __controlPoints: null;
+  index: number;
+}
+
+export interface GraphData {
+  nodes: Node[];
+  links: Link[];
+}
+
 export type Context = CanvasRenderingContext2D;
 
 // Auth

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,7 +4,7 @@ export type NodeObject = object & {
   name?: string;
   x?: number;
   y?: number;
-  isActive?: boolean;
+  isWritten?: boolean;
   vx?: number;
   vy?: number;
   fx?: number;
@@ -14,7 +14,7 @@ export type NodeObject = object & {
 export interface Node extends NodeObject {
   name?: string;
   connect_count?: number;
-  isActive?: boolean;
+  isWritten?: boolean;
 }
 
 export type Context = CanvasRenderingContext2D;
@@ -38,14 +38,14 @@ export interface FormButtonProps {
 export interface ModalProps {
   isOpen: boolean;
   onRequestClose: () => void;
-  updateNodeInfo: (id: number | string, isActive: boolean) => void;
+  updateNodeInfo: (id: number | string, isWritten: boolean) => void;
 }
 
 // WirteModal
 export interface WriteModalProps {
   isOpen: boolean;
   onRequestClose: () => void;
-  updateNodeInfo: (id: number | string, isActive: boolean) => void;
+  updateNodeInfo: (id: number | string, isWritten: boolean) => void;
 }
 
 // ListModal

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -13,7 +13,7 @@ export type NodeObject = object & {
 
 export interface Node extends NodeObject {
   name?: string;
-  connect_count?: number;
+  connectCount?: number;
   isWritten?: boolean;
 }
 


### PR DESCRIPTION
## Summary
노드 정보를 받아오는 api 연결

## Description
- 기존의 더미 api 삭제
- react-query 연결
- 기존의 `isActive` 변수 `isWritten`으로 수정
- 일부 타입 인터페이스 수정

## Screenshots
<img width="981" alt="image" src="https://github.com/techeer-sv/Mindspace_front/assets/78795820/b0474cf0-2236-47ea-a2d8-71f94ae57c51">


## Test Checklist

테스트 실행전, 노드정보를 테이블에 입력해야합니다.
연결정보는 더미로 진행하고있기때문에 실제로 30개정도의 노드아이디값이 전부 들어가야 에러가 나지않아요.

![image](https://github.com/techeer-sv/Mindspace_front/assets/78795820/6580f1a2-b90e-45c0-b9d7-055cd85d1cd3)

IntelliJ기준 위 버튼을 눌러 아래의 sql문을 실행시키면 정상적으로 더미 노드정보가 들어갑니다.

```
INSERT INTO `node` (`node_name`, `create_at`, `updated_at`) VALUES
('Javascript', NOW(), NOW()),
('Webpack', NOW(), NOW()),
('React', NOW(), NOW()),
('JavaScript Immutability', NOW(), NOW()),
('Ajax', NOW(), NOW()),
('React Route', NOW(), NOW()),
('State Management', NOW(), NOW()),
('Class vs Component', NOW(), NOW()),
('React Query', NOW(), NOW()),
('Jest', NOW(), NOW()),
('ES6', NOW(), NOW()),
('Redux', NOW(), NOW()),
('Mobx', NOW(), NOW()),
('Zustand', NOW(), NOW()),
('Recoil', NOW(), NOW()),
('Redux saga', NOW(), NOW()),
('Redux toolkit', NOW(), NOW()),
('Browser Render', NOW(), NOW()),
('HTML', NOW(), NOW()),
('Proxy', NOW(), NOW()),
('Auth', NOW(), NOW()),
('OAuth2.0', NOW(), NOW()),
('FaceBook Login', NOW(), NOW()),
('Kakao Login', NOW(), NOW()),
('Bearer Auth', NOW(), NOW()),
('JWT Token', NOW(), NOW()),
('CSS', NOW(), NOW()),
('CSS vs CSS in JS', NOW(), NOW()),
('SASS', NOW(), NOW()),
('Tailwind', NOW(), NOW()),
('Bootstrap', NOW(), NOW()),
('Styled-compoent', NOW(), NOW()),
('Material-UI', NOW(), NOW());


```
- [x] 회원가입 후 http://localhost:5173/map 페이지로 이동했을때 노드정보가 렌더링되는지 확인해주세요

- [x] 직접 게시글을 작성한후 (swagger를 사용하거나, db에 값을 업데이트해서) 새로고침했을때 작성된 글의 별자리가 빛나는지 확인해주세요


## [논의사항 & 이슈]

노드맵 페이지에 대한 테스트코드는 호환성이슈로 진행하지 못했습니다ㅜㅜ.. 관련된 내용과 조사한내용을 아래 링크로 첨부합니다.
https://www.notion.so/dr0joon/react-force-graph-JEST-b271c6e263394dada1a71f9d7ff3c8bb
